### PR TITLE
添加显示User.DisplayName notsave 字段

### DIFF
--- a/wojilu.Core/Members/Users/Domain/User.cs
+++ b/wojilu.Core/Members/Users/Domain/User.cs
@@ -240,7 +240,24 @@ namespace wojilu.Members.Users.Domain {
             set { _realId = value; }
         }
 
-
+        /// <summary>
+        /// 显示的名称：UserName用户名，RealName真实姓名
+        /// </summary>
+        [NotSave]
+        public string DisplayName
+        {
+            get
+            {
+                if (config.Instance.Site.UserDisplayName == Config.UserDisplayNameType.RealName && String.IsNullOrEmpty(this.RealName) != true)
+                    return this.RealName;
+                else if (config.Instance.Site.UserDisplayName == Config.UserDisplayNameType.Name)
+                    return this.Name;
+                else if (String.IsNullOrEmpty(this.RealName) != true)
+                    return this.RealName;
+                else
+                    return this.Name;
+            }
+        }
     }
 }
 

--- a/wojilu/Config/SiteSetting.cs
+++ b/wojilu/Config/SiteSetting.cs
@@ -82,6 +82,15 @@ namespace wojilu.Config {
     }
 
     /// <summary>
+    /// 显示名称：Name 用户名，RealName 真实姓名，默认为RealName
+    /// </summary>
+    public class UserDisplayNameType
+    {
+        public static readonly int RealName = 1;
+        public static readonly int Name = 2;
+    }
+
+    /// <summary>
     /// 网站配置
     /// </summary>
     public class SiteSetting {
@@ -391,6 +400,26 @@ namespace wojilu.Config {
 
             return false;
         }
+
+        /// <summary>
+        /// 使用MS的Membership数据库验证登录，需要配合AuthenticationModule的自动注册功能一起使用,默认为否
+        /// </summary>
+        public Boolean ValidateUserByMembership { get; set; }
+
+        /// <summary>
+        /// 显示名称：Name 用户名，RealName 真实姓名，默认为RealName
+        /// </summary>
+        public int UserDisplayName { get; set; }
+
+        /// <summary>
+        /// 是否禁止修改真实性名与空间名称，默认不禁止
+        /// </summary>
+        public Boolean DenyEditUserRealName { get; set; }
+
+        /// <summary>
+        /// 是否禁止修改空间名称，默认不禁止
+        /// </summary>
+        public Boolean DenyEditUserTitle { get; set; }
 
         //------------------------------filter----------------------------------
 

--- a/wojilu/Config/config.cs
+++ b/wojilu/Config/config.cs
@@ -197,6 +197,11 @@ namespace wojilu {
 
             _siteSetting.CloseComment = cvt.ToBool( getVal( dic, "CloseComment" ) );
 
+            _siteSetting.UserDisplayName = cvt.ToInt(getVal(dic, "UserDisplayName"));
+            _siteSetting.ValidateUserByMembership = cvt.ToBool(getVal(dic, "ValidateUserByMembership"));
+            _siteSetting.DenyEditUserRealName = cvt.ToBool(getVal(dic, "DenyEditUserRealName"));
+            _siteSetting.DenyEditUserTitle = cvt.ToBool(getVal(dic, "DenyEditUserTitle"));
+
             _siteSetting.setValueAll( dic );
         }
 


### PR DESCRIPTION
/// <summary>


        /// 使用MS的Membership数据库验证登录，需要配合AuthenticationModule的自动注册功能一起使用,默认为否
        /// </summary>


        public Boolean ValidateUserByMembership { get; set; }

```
    /// <summary>
    /// 显示名称：Name 用户名，RealName 真实姓名，默认为RealName
    /// </summary>
    public int UserDisplayName { get; set; }

    /// <summary>
    /// 是否禁止修改真实性名与空间名称，默认不禁止
    /// </summary>
    public Boolean DenyEditUserRealName { get; set; }

    /// <summary>
    /// 是否禁止修改空间名称，默认不禁止
    /// </summary>
    public Boolean DenyEditUserTitle { get; set; }
```
